### PR TITLE
Bugfix compute PGN

### DIFF
--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -582,8 +582,19 @@ def _generate_declarations(database_name, messages):
 
 def _compute_pgn(id: int):
     PGN_OFFSET = 8
-    PGN_MASK = 0x3FFFF
-    pgn = (id >> PGN_OFFSET) & PGN_MASK
+    PGN_MASK = 0x3ffff
+    DATA_PAGE_OFFSET = 24
+    DATA_PAGE_MASK = 1
+    PDU_FORMAT_OFFSET = 16
+    PDU_FORMAT_MASK = 0xff
+
+    data_page = (DATA_PAGE_OFFSET >> 24) & DATA_PAGE_MASK
+    pdu_format = (id >> PDU_FORMAT_OFFSET) & PDU_FORMAT_MASK
+
+    if pdu_format < 240:    # PDU1
+        pgn = (data_page << 9) | (pdu_format << 8)
+    else:                   # PDU2
+        pgn = (id >> PGN_OFFSET) & PGN_MASK
     return f'{hex(pgn)}'
 
 def _signal_ostream_body(message_name, signal):


### PR DESCRIPTION
Calculating PGN from message ID was incorrect for messages with PDU1 format messages. The last byte is always zero.

From A Comprehensible Guide to J1939 page 55-6
PDU1 PGN:
![image](https://user-images.githubusercontent.com/4053231/95527353-e3af0600-0989-11eb-9d53-e03486f1f07c.png)

PDU2 PGN:
![image](https://user-images.githubusercontent.com/4053231/95527563-7bacef80-098a-11eb-9142-ef3c06213186.png)


Additional references:
* http://www.simmasoftware.com/j1939-presentation.pdf
* https://tractorhacking.github.io/documentation/TechNotesJ1939.html