### PR TITLE
C++ generation string signal

### DIFF
--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -119,11 +119,6 @@ public:
 }};
 '''
 
-# SIGNAL_DECLARATION_OVERRIDES = '''\
-#     virtual {physical_type} Decode({type_name} value) const override;
-#     virtual {type_name} Encode({physical_type} value) const override;
-# '''
-
 MESSAGE_DECLARATION_FMT = '''\
 {signal_constructors}
 
@@ -259,13 +254,6 @@ def _signal_physical_type_is_string(signal):
 
 def _signal_physical_type(signal):
     return 'std::string' if _signal_physical_type_is_string(signal) else 'double'
-
-# def _signal_overrides(signal):
-#     if _signal_physical_type_is_string(signal):
-#         return SIGNAL_DECLARATION_OVERRIDES.format(
-#             type_name=signal.type_name,
-#             physical_type=_signal_physical_type(signal))
-#     return ''
 
 def _generate_signal_declaration(signal, message_name):
     comment = _format_comment_no_tabs(signal.comment)
@@ -728,9 +716,6 @@ def _generate_definitions(database_name, messages):
                 type_name=signal.type_name,
                 check=range_checks[signal_iter])
 
-            # If signal physical data type is string, have specialized functionality for Signal::Encode and
-            # Signal::Decode
-            # if _signal_physical_type_is_string(signal):
             signal_definition += SIGNAL_DEFINITION_DECODE_FMT.format(
                 name=signal.name,
                 message_name=message.name,

--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -224,11 +224,13 @@ def _format_comment_no_tabs(comment):
     else:
         return ''
 
+
 # TODO this should evaluate outputs to integers/bools as well, just not only std::string or double
 def _signal_physical_type(signal):
     if signal.unit and (signal.unit.lower() == 'string' or signal.unit.lower() == 'str'):
         return 'std::string'
     return 'double'
+
 
 def _generate_signal_declaration(signal, message_name):
     comment = _format_comment_no_tabs(signal.comment)

--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -89,7 +89,7 @@ SOURCE_FMT = '''\
 
 #include <cstdlib>
 #include <cstring>
-#include <iostream>
+#include <ostream>
 
 {definitions}\
 '''
@@ -656,11 +656,9 @@ def _signal_ostream_body(message_name, signal):
 
 def _signal_decode_body(signal):
     if _signal_physical_type_is_string(signal):
-        return f'{CPP_TAB}std::stringstream sstream;\n' \
-               f'{CPP_TAB}unsigned char char_arr[sizeof(value)];\n' \
+        return f'{CPP_TAB}unsigned char char_arr[sizeof(value)];\n' \
                f'{CPP_TAB}std::memcpy(char_arr, &value, sizeof(value));\n' \
-               f'{CPP_TAB}sstream << char_arr;\n' \
-               f'{CPP_TAB}return sstream.str();'
+               f'{CPP_TAB}return std::string(reinterpret_cast<const char*>(char_arr), sizeof(char_arr) / sizeof(char_arr[0]));'
     else:
         return f'{CPP_TAB}' + DEFAULT_SIGNAL_DECODE_BODY.format(physical_type=_signal_physical_type(signal))
 

--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -226,6 +226,12 @@ def _format_comment_no_tabs(comment):
 
 
 # TODO this should evaluate outputs to integers/bools as well, just not only std::string or double
+# This would require all input DBC files to be modified so that each signal has a corresponding
+# SIG_VALTYPE_ attribute in the signal_valtype_list section. See reference, pg 5-6:
+# http://read.pudn.com/downloads766/ebook/3041455/DBC_File_Format_Documentation.pdf
+# If this is done then can use signal.type_name, with some simple code to determine if the signal is
+# a boolean (1 bit size). Then can make use of Signal template param PhysicalDataType accurately, as
+# well as hardcode the `std::ostream& operator<<(` with partial template specialization.
 def _signal_physical_type(signal):
     if signal.unit and (signal.unit.lower() == 'string' or signal.unit.lower() == 'str'):
         return 'std::string'

--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -658,14 +658,17 @@ def _signal_decode_body(signal):
     if _signal_physical_type_is_string(signal):
         return f'{CPP_TAB}unsigned char char_arr[sizeof(value)];\n' \
                f'{CPP_TAB}std::memcpy(char_arr, &value, sizeof(value));\n' \
-               f'{CPP_TAB}return std::string(reinterpret_cast<const char*>(char_arr), sizeof(char_arr) / sizeof(char_arr[0]));'
+               f'{CPP_TAB}std::string out(reinterpret_cast<const char*>(char_arr), sizeof(char_arr) / sizeof(char_arr[0]));\n' \
+               f'{CPP_TAB}out.resize(strlen(out.c_str()));\n' \
+               f'{CPP_TAB}return out;'
     else:
         return f'{CPP_TAB}' + DEFAULT_SIGNAL_DECODE_BODY.format(physical_type=_signal_physical_type(signal))
 
 def _signal_encode_body(signal):
     if _signal_physical_type_is_string(signal):
-        return f'{CPP_TAB}char *end;\n' \
-               f'{CPP_TAB}return std::strtoull(value.data(), &end, 10);'
+        return f'{CPP_TAB}uint64_t out = 0;\n' \
+               f'{CPP_TAB}std::memcpy(&out, value.c_str(), sizeof(out));\n' \
+               f'{CPP_TAB}return out;'
     else:
         return f'{CPP_TAB}' + DEFAULT_SIGNAL_ENCODE_BODY.format(type_name=signal.type_name)
 

--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -646,7 +646,7 @@ def _signal_ostream_body(message_name, signal):
         if signal.unit.lower() != 'bool':
             ostream_body = f'{CPP_TAB}os << signal.Real()'
         else:
-            // TODO static_cast<bool> around signal until bool is a PhysicalDataType option
+            # TODO static_cast<bool> around signal until bool is a PhysicalDataType option
             ostream_body = f'{CPP_TAB}os << std::boolalpha << static_cast<bool>(signal.Real()) << std::noboolalpha'
         if signal.unit.lower() != 'string' and signal.unit.lower() != 'str' and signal.unit.lower() != 'enum' and \
            signal.unit.lower() != 'bool' and signal.unit != ' ' and signal.unit != '' and signal.unit != '-':

--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -648,7 +648,7 @@ def _signal_ostream_body(message_name, signal):
             ostream_body = f'{CPP_TAB}os << signal.Real()'
         else:
             ostream_body = f'{CPP_TAB}os << std::boolalpha << signal.Real() << std::noboolalpha'
-        if signal.unit.lower() != 'string' and signal.unit.lower() != 'enum' and \
+        if signal.unit.lower() != 'string' and signal.unit.lower() != 'str' and signal.unit.lower() != 'enum' and \
            signal.unit.lower() != 'bool' and signal.unit != ' ' and signal.unit != '' and signal.unit != '-':
             ostream_body += f' << " " << signal.data_format()'
         ostream_body += ';'

--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -224,13 +224,11 @@ def _format_comment_no_tabs(comment):
     else:
         return ''
 
-def _signal_physical_type_is_string(signal):
-    if signal.unit and (signal.unit.lower() == 'string' or signal.unit.lower() == 'str'):
-        return True
-    return False
-
+# TODO this should evaluate outputs to integers/bools as well, just not only std::string or double
 def _signal_physical_type(signal):
-    return 'std::string' if _signal_physical_type_is_string(signal) else 'double'
+    if signal.unit and (signal.unit.lower() == 'string' or signal.unit.lower() == 'str'):
+        return 'std::string'
+    return 'double'
 
 def _generate_signal_declaration(signal, message_name):
     comment = _format_comment_no_tabs(signal.comment)

--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -646,6 +646,7 @@ def _signal_ostream_body(message_name, signal):
         if signal.unit.lower() != 'bool':
             ostream_body = f'{CPP_TAB}os << signal.Real()'
         else:
+            // TODO static_cast<bool> around signal until bool is a PhysicalDataType option
             ostream_body = f'{CPP_TAB}os << std::boolalpha << static_cast<bool>(signal.Real()) << std::noboolalpha'
         if signal.unit.lower() != 'string' and signal.unit.lower() != 'str' and signal.unit.lower() != 'enum' and \
            signal.unit.lower() != 'bool' and signal.unit != ' ' and signal.unit != '' and signal.unit != '-':

--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -86,6 +86,8 @@ SOURCE_FMT = '''\
 
 #include "{header}"
 
+#include <ostream>
+
 {definitions}\
 '''
 
@@ -134,10 +136,6 @@ public:
 {static_vars}
 }};
 '''
-
-DEFAULT_SIGNAL_DECODE_BODY = 'return ((static_cast<{physical_type}>(value) * scale_factor_) + offset_);'
-
-DEFAULT_SIGNAL_ENCODE_BODY = 'return static_cast<{type_name}>((value - offset_) / scale_factor_);'
 
 MESSAGE_SIGNAL_SETTER_DECLARATION_FMT = '''\
 bool set_{name}(const double& value);

--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -646,7 +646,7 @@ def _signal_ostream_body(message_name, signal):
         if signal.unit.lower() != 'bool':
             ostream_body = f'{CPP_TAB}os << signal.Real()'
         else:
-            ostream_body = f'{CPP_TAB}os << std::boolalpha << signal.Real() << std::noboolalpha'
+            ostream_body = f'{CPP_TAB}os << std::boolalpha << static_cast<bool>(signal.Real()) << std::noboolalpha'
         if signal.unit.lower() != 'string' and signal.unit.lower() != 'str' and signal.unit.lower() != 'enum' and \
            signal.unit.lower() != 'bool' and signal.unit != ' ' and signal.unit != '' and signal.unit != '-':
             ostream_body += f' << " " << signal.data_format()'

--- a/cantools/database/can/templates/DBC.h
+++ b/cantools/database/can/templates/DBC.h
@@ -2,6 +2,8 @@
 #define CANTOOLS_DBC_H
 
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <iomanip>
 #include <memory>
 #include <string>
@@ -199,10 +201,88 @@ class Signal {
   }
 
   /** Decode given signal by applying scaling and offset. */
-  virtual PhysicalDataType Decode(RawDataType value) const = 0;
+  virtual PhysicalDataType Decode(RawDataType value) const {
+    return ((static_cast<PhysicalDataType>(value) * scale_factor_) + offset_);
+  }
 
   /** Encode given signal by applying scaling and offset. */
-  virtual RawDataType Encode(PhysicalDataType value) const = 0;
+  virtual RawDataType Encode(PhysicalDataType value) const {
+    return static_cast<RawDataType>((value - offset_) / scale_factor_);
+  }
+
+  /** Return string of data format, empty if none */
+  std::string data_format() const { return data_format_; }
+
+  /** Return SPN, 0 if none */
+  uint32_t spn() const { return spn_; }
+
+ protected:
+  // Const pointer to buffer that signal is packed into
+  const uint8_t* buffer_;
+
+  // Signal name
+  std::string name_;
+
+  // Offset value used for encode/decode, unitless
+  double offset_ {0.0};
+
+  // Scale factor used for encode/decode, unitless
+  double scale_factor_ {1.0};
+
+  // Data format name
+  std::string data_format_ {""};
+
+  // Suspect Parameter Number (SPN) for J1939 signal
+  uint32_t spn_ {J1939_INVALID_SPN};
+};
+
+/** Partial template specialization for std::string PhysicalDataType */
+template<typename RawDataType>
+class Signal<RawDataType, std::string> {
+ public:
+  Signal(const uint8_t* buffer, const std::string& name)
+      : buffer_(buffer),
+        name_(name) {}
+
+  Signal(const uint8_t* buffer, const std::string& name, const double offset,
+         const double scale, const std::string& data_format, const uint32_t spn)
+      : buffer_(buffer),
+        name_(name),
+        offset_(offset),
+        scale_factor_(scale),
+        data_format_(data_format),
+        spn_(spn) {}
+
+  /** Unpack signal from buffer */
+  virtual RawDataType Raw() const = 0;
+
+  /** Confirm if raw signal within acceptable range */
+  virtual bool RawInRange(const RawDataType& value) const = 0;  
+
+  /** Unpacked signal from buffer, decoded and converted to physical engineering units */
+  std::string Real() const { return Decode(Raw()); }
+
+  /** Confirm if physical engineering units value in range */
+  bool InRange(const std::string& value) const {
+    RawDataType raw = Encode(value);
+    return RawInRange(raw);
+  }
+
+  /** Decode given signal by applying scaling and offset. */
+  virtual std::string Decode(RawDataType value) const {
+    unsigned char char_arr[sizeof(value)];
+    std::memcpy(char_arr, &value, sizeof(value));
+    std::string out(reinterpret_cast<const char*>(char_arr), sizeof(char_arr) / sizeof(char_arr[0]));
+    out.resize(strlen(out.c_str()));
+    return out;
+  }
+
+  /** Encode given signal by applying scaling and offset. */
+  virtual RawDataType Encode(std::string value) const {
+    uint64_t out = 0;
+    std::memcpy(&out, value.c_str(), sizeof(out));
+    return out;
+  }
 
   /** Return string of data format, empty if none */
   std::string data_format() const { return data_format_; }

--- a/cantools/database/can/templates/DBC.h
+++ b/cantools/database/can/templates/DBC.h
@@ -270,9 +270,7 @@ class Signal<RawDataType, std::string> {
 
   /** Decode given signal by applying scaling and offset. */
   std::string Decode(RawDataType value) const {
-    unsigned char char_arr[sizeof(value)];
-    std::memcpy(char_arr, &value, sizeof(value));
-    std::string out(reinterpret_cast<const char*>(char_arr), sizeof(char_arr) / sizeof(char_arr[0]));
+    std::string out(reinterpret_cast<const char*>(&value), sizeof(value));
     out.resize(strlen(out.c_str()));
     return out;
   }

--- a/cantools/database/can/templates/DBC.h
+++ b/cantools/database/can/templates/DBC.h
@@ -201,12 +201,12 @@ class Signal {
   }
 
   /** Decode given signal by applying scaling and offset. */
-  virtual PhysicalDataType Decode(RawDataType value) const {
+  PhysicalDataType Decode(RawDataType value) const {
     return ((static_cast<PhysicalDataType>(value) * scale_factor_) + offset_);
   }
 
   /** Encode given signal by applying scaling and offset. */
-  virtual RawDataType Encode(PhysicalDataType value) const {
+  RawDataType Encode(PhysicalDataType value) const {
     return static_cast<RawDataType>((value - offset_) / scale_factor_);
   }
 
@@ -269,7 +269,7 @@ class Signal<RawDataType, std::string> {
   }
 
   /** Decode given signal by applying scaling and offset. */
-  virtual std::string Decode(RawDataType value) const {
+  std::string Decode(RawDataType value) const {
     unsigned char char_arr[sizeof(value)];
     std::memcpy(char_arr, &value, sizeof(value));
     std::string out(reinterpret_cast<const char*>(char_arr), sizeof(char_arr) / sizeof(char_arr[0]));
@@ -278,7 +278,7 @@ class Signal<RawDataType, std::string> {
   }
 
   /** Encode given signal by applying scaling and offset. */
-  virtual RawDataType Encode(std::string value) const {
+  RawDataType Encode(std::string value) const {
     uint64_t out = 0;
     std::memcpy(&out, value.c_str(), sizeof(out));
     return out;

--- a/cantools/database/can/templates/DBC.h
+++ b/cantools/database/can/templates/DBC.h
@@ -194,19 +194,15 @@ class Signal {
 
   /** Confirm if physical engineering units value in range */
   bool InRange(const PhysicalDataType& value) const {
-    RawDataType enable = Encode(value);
-    return RawInRange(enable);
+    RawDataType raw = Encode(value);
+    return RawInRange(raw);
   }
 
   /** Decode given signal by applying scaling and offset. */
-  PhysicalDataType Decode(RawDataType value) const {
-    return ((static_cast<PhysicalDataType>(value) * scale_factor_) + offset_);
-  }
+  virtual PhysicalDataType Decode(RawDataType value) const = 0;
 
   /** Encode given signal by applying scaling and offset. */
-  RawDataType Encode(PhysicalDataType value) const {
-    return static_cast<RawDataType>((value - offset_) / scale_factor_);
-  }
+  virtual RawDataType Encode(PhysicalDataType value) const = 0;
 
   /** Return string of data format, empty if none */
   std::string data_format() const { return data_format_; }

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -61,6 +61,7 @@ filegroup(
         "//tests:files/dbc/CSS-Electronics-SAE-J1939-DEMO.dbc",
         "//tests:files/dbc/motohawk.dbc",
         "//tests:files/dbc/signed.dbc",
+        "//tests:files/dbc/string_signals.dbc",
     ],
 )
 

--- a/tests/files/dbc/string_signals.dbc
+++ b/tests/files/dbc/string_signals.dbc
@@ -36,6 +36,9 @@ BS_:
 BU_:
 
 
-BO_ 10 PersonName: 40 Vector___XXX
+BO_ 10 PersonName: 42 Vector___XXX
  SG_ first_name : 0|160@1+ (1,0) [0|0] "String" Vector__XXX
- SG_ last_name : 160|160@1+ (1,0) [0|0] "str" Vector__XXX
+ SG_ age : 160|8@1+ (1,0) [0|254] "years" Vector__XXX
+ SG_ last_name : 168|160@1+ (1,0) [0|0] "str" Vector__XXX
+ SG_ height : 328|7@1+ (1,0) [0|0] "inches" Vector__XXX
+ SG_ _reserved : 335|1@1+ (1,0) [0|0] "" Vector__XXX

--- a/tests/files/dbc/string_signals.dbc
+++ b/tests/files/dbc/string_signals.dbc
@@ -41,4 +41,4 @@ BO_ 10 PersonName: 42 Vector___XXX
  SG_ age : 160|8@1+ (1,0) [0|254] "years" Vector__XXX
  SG_ last_name : 168|160@1+ (1,0) [0|0] "str" Vector__XXX
  SG_ height : 328|7@1+ (1,0) [0|0] "inches" Vector__XXX
- SG_ _reserved : 335|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ alive : 335|1@1+ (1,0) [0|0] "Bool" Vector__XXX

--- a/tests/files/dbc/string_signals.dbc
+++ b/tests/files/dbc/string_signals.dbc
@@ -1,0 +1,41 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_:
+
+
+BO_ 10 PersonName: 40 Vector___XXX
+ SG_ first_name : 0|160@1+ (1,0) [0|0] "String" Vector__XXX
+ SG_ last_name : 160|160@1+ (1,0) [0|0] "str" Vector__XXX

--- a/tests/test_generate_cpp.cpp
+++ b/tests/test_generate_cpp.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 
 #include "motohawk.h"
+#include "string_signals.h"
 #include "signed.h"
 #include "css__electronics_sae_j1939_demo.h"
 
@@ -103,6 +104,24 @@ TEST(GenerateCpp, test_OstreamOperator_Motohawk_DBC) {
     os.str(std::string());
     os << m;
     EXPECT_EQ(os.str(), "Enable: 0  AverageRadius: 0.2 m  Temperature: 250 degK");
+}
+
+TEST(GenerateCpp, test_SignalStringType_String_DBC) {
+    PersonName full_name;
+    full_name.set_first_name("John");
+    full_name.set_last_name("Doe");
+
+    std::stringstream os;
+    os << full_name.first_name;
+    EXPECT_EQ(os.str(), "John");
+
+    os.str(std::string());
+    os << full_name.last_name;
+    EXPECT_EQ(os.str(), "Doe");
+
+    os.str(std::string());
+    os << full_name;
+    EXPECT_EQ(os.str(), "first_name: John  last_name: Doe");
 }
 
 int main(int argc, char **argv) {

--- a/tests/test_generate_cpp.cpp
+++ b/tests/test_generate_cpp.cpp
@@ -112,6 +112,7 @@ TEST(GenerateCpp, test_SignalStringType_String_DBC) {
     full_name.set_last_name("Doe");
     full_name.set_height(67);
     full_name.set_age(26);
+    full_name.set_alive(true);
 
     std::stringstream os;
     os << full_name.first_name;
@@ -129,10 +130,13 @@ TEST(GenerateCpp, test_SignalStringType_String_DBC) {
     os << full_name.age;
     EXPECT_EQ(os.str(), "26 years");
 
+    os.str(std::string());
+    os << full_name.alive;
+    EXPECT_EQ(os.str(), "true");
 
     os.str(std::string());
     os << full_name;
-    EXPECT_EQ(os.str(), "first_name: John  age: 26 years  last_name: Doe  height: 67 inches  _reserved: 0");
+    EXPECT_EQ(os.str(), "first_name: John  age: 26 years  last_name: Doe  height: 67 inches  alive: true");
 }
 
 int main(int argc, char **argv) {

--- a/tests/test_generate_cpp.cpp
+++ b/tests/test_generate_cpp.cpp
@@ -110,6 +110,8 @@ TEST(GenerateCpp, test_SignalStringType_String_DBC) {
     PersonName full_name;
     full_name.set_first_name("John");
     full_name.set_last_name("Doe");
+    full_name.set_height(67);
+    full_name.set_age(26);
 
     std::stringstream os;
     os << full_name.first_name;
@@ -120,8 +122,17 @@ TEST(GenerateCpp, test_SignalStringType_String_DBC) {
     EXPECT_EQ(os.str(), "Doe");
 
     os.str(std::string());
+    os << full_name.height;
+    EXPECT_EQ(os.str(), "67 inches");
+
+    os.str(std::string());
+    os << full_name.age;
+    EXPECT_EQ(os.str(), "26 years");
+
+
+    os.str(std::string());
     os << full_name;
-    EXPECT_EQ(os.str(), "first_name: John  last_name: Doe");
+    EXPECT_EQ(os.str(), "first_name: John  age: 26 years  last_name: Doe  height: 67 inches  _reserved: 0");
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Partial template specialization for Frame class when PhysicalDataType is std::string. This allows us to get/set std::string values for Signals.

Would like feedback on conversion methods for `uint*` <-> `std::string` - more efficient or better approach?