### PR TITLE
Support strings longer than 8 chars

### DIFF
--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -318,12 +318,18 @@ def _format_pack_code_mux(message,
 
 def _format_pack_code_string(signal):
     start = signal.start // 8
-    body_lines = []
-    body_lines.append(f'{CPP_TAB}clear_{signal.name}();\n')
+    length = signal.length // 8
 
-    for index, _, _, _ in signal.segments(invert_shift=False):
-        body_lines.append(f'{CPP_TAB}buffer_[{index}] = value[{index - start}];')
-    body_lines.append(f'{CPP_TAB}return true;')
+    body_lines = [
+        f'{CPP_TAB}clear_{signal.name}();',
+        f'{CPP_TAB}int index = {start};',
+        f'{CPP_TAB}for (const auto& c : value) {{',
+        f'{CPP_TAB}{CPP_TAB}if (index >= {length + start}) {{ break; }}',
+        f'{CPP_TAB}{CPP_TAB}buffer_[index] = c;',
+        f'{CPP_TAB}{CPP_TAB}index++;',
+        f'{CPP_TAB}}}',
+        f'{CPP_TAB}return true;'
+    ]
     return '\n'.join(body_lines)
 
 

--- a/cantools/database/can/cpp_source.py
+++ b/cantools/database/can/cpp_source.py
@@ -454,8 +454,14 @@ def _format_unpack_code_string(signal):
     start = signal.start // 8
     body_lines = [
         f'{CPP_TAB}char buff[{length + 1}];',
-        f'{CPP_TAB}std::memcpy(buff, buffer_ + {start}, {length});',
-        f'{CPP_TAB}buff[{length}] = 0;',
+        f'{CPP_TAB}int index = 0;',
+        f'{CPP_TAB}while (index < {length}) {{',
+        f'{CPP_TAB}{CPP_TAB}char c = buffer_[index + {start}];',
+        f'{CPP_TAB}{CPP_TAB}if (c == (char)0xff || c == 0) {{ break; }}',
+        f'{CPP_TAB}{CPP_TAB}buff[index] = c;',
+        f'{CPP_TAB}{CPP_TAB}index++;',
+        f'{CPP_TAB}}}',
+        f'{CPP_TAB}buff[index] = 0;',
         f'{CPP_TAB}return std::string(buff);',
     ]
     return '\n'.join(body_lines)

--- a/cantools/database/can/templates/DBC.h
+++ b/cantools/database/can/templates/DBC.h
@@ -270,10 +270,12 @@ class Signal<RawDataType, std::string> {
   virtual RawDataType Raw() const = 0;
 
   /** Confirm if raw signal within acceptable range */
-  virtual bool RawInRange(const RawDataType& value) const = 0;  
+  virtual bool RawInRange(const RawDataType& value) const = 0;
 
   /** Unpacked signal from buffer, decoded and converted to physical engineering units */
-  std::string Real() const { return Decode(Raw()); }
+  std::string Real() const {
+    return Raw();
+  }
 
   /** Confirm if physical engineering units value in range */
   bool InRange(const std::string& value) const {
@@ -281,11 +283,9 @@ class Signal<RawDataType, std::string> {
     return RawInRange(raw);
   }
 
-  /** Decode given signal by applying scaling and offset. */
+  /** This is a no-op for string-string conversion! */
   std::string Decode(RawDataType value) const {
-    std::string out(reinterpret_cast<const char*>(&value), sizeof(value));
-    out.resize(strlen(out.c_str()));
-    return out;
+    return value;
   }
 
   /** Encode given signal by applying scaling and offset. */

--- a/tests/test_generate_cpp.cpp
+++ b/tests/test_generate_cpp.cpp
@@ -219,6 +219,10 @@ TEST(GenerateCpp, test_SignalStringType_StringDBC) {
     os.str(std::string());
     os << full_name;
     EXPECT_EQ(os.str(), "first_name: Johnathan  age: 26 years  last_name: Doe  height: 67 inches  alive: true");
+
+    PersonName too_long;
+    too_long.set_first_name("Thisnameislongerthantwentycharacterssoitshouldtruncate");
+    EXPECT_EQ(too_long.first_name.Real(), "Thisnameislongerthan");
 }
 
 int main(int argc, char **argv) {

--- a/tests/test_generate_cpp.cpp
+++ b/tests/test_generate_cpp.cpp
@@ -158,7 +158,7 @@ TEST(GenerateCpp, test_SPNs_CSSElectronicsSAEJ1939DBC) {
 
     EXPECT_EQ(eec1.EngineSpeed.spn(), 190);
     EXPECT_EQ(ccvs1.WheelBasedVehicleSpeed.spn(), 84);
-    
+
     // Test static member vars
     EXPECT_EQ(EEC1::cycle_time_ms, 500);
     EXPECT_EQ(CCVS1::ID, 0x18fef1fe);
@@ -174,7 +174,7 @@ TEST(GenerateCpp, test_OstreamOperator_MotohawkDBC) {
     std::stringstream os;
     os << m.AverageRadius;
     EXPECT_EQ(os.str(), "0.2 m");
-    
+
     os.str(std::string());
     os << m.Temperature;
     EXPECT_EQ(os.str(), "250 degK");
@@ -190,7 +190,7 @@ TEST(GenerateCpp, test_OstreamOperator_MotohawkDBC) {
 
 TEST(GenerateCpp, test_SignalStringType_StringDBC) {
     PersonName full_name;
-    full_name.set_first_name("John");
+    full_name.set_first_name("Johnathan");
     full_name.set_last_name("Doe");
     full_name.set_height(67);
     full_name.set_age(26);
@@ -198,7 +198,7 @@ TEST(GenerateCpp, test_SignalStringType_StringDBC) {
 
     std::stringstream os;
     os << full_name.first_name;
-    EXPECT_EQ(os.str(), "John");
+    EXPECT_EQ(os.str(), "Johnathan");
 
     os.str(std::string());
     os << full_name.last_name;
@@ -218,7 +218,7 @@ TEST(GenerateCpp, test_SignalStringType_StringDBC) {
 
     os.str(std::string());
     os << full_name;
-    EXPECT_EQ(os.str(), "first_name: John  age: 26 years  last_name: Doe  height: 67 inches  alive: true");
+    EXPECT_EQ(os.str(), "first_name: Johnathan  age: 26 years  last_name: Doe  height: 67 inches  alive: true");
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
We were stuffing strings into a uint64_t, which worked fine for strings < 8 chars, but longer strings were resulting in weird behavior, because they were ORing random values from memory onto the decoded value. This PR uses strings everywhere instead of converting to an int value.